### PR TITLE
FIX Check property exists rather than isset for policies property

### DIFF
--- a/code/ControllerPolicyApplicator.php
+++ b/code/ControllerPolicyApplicator.php
@@ -38,7 +38,7 @@ class ControllerPolicyApplicator extends Extension
 
     public function getPolicies()
     {
-        if (isset($this->owner) && isset($this->owner->policies)) {
+        if (isset($this->owner) && property_exists($this->owner, 'policies')) {
             return $this->owner->policies;
         }
     }


### PR DESCRIPTION
Prevents error e.g. "Undefined property: DatabaseAdmin::$policies", despite being in an isset check.

Noticed against silverstripe/silverstripe-framework#b1dc2cc9f9e7ee2948e2775b940239f20abde8c3